### PR TITLE
Fix(ui): process '\n' in dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ export JAVA_HOME=
 
 即可启动Zeppelin。
 
+#### 常见问题
+
+##### Windows上启动时出现警告日志 
+
+```
+java.io.FileNotFoundException: C:\Zeppelin\zeppelin-web-angular\dist
+```
+参考[这个问答](https://stackoverflow.com/questions/61078714/apache-zeppelin-not-loading-in-a-browser-in-windows-10)解决。
+
+#### Windows上运行，解释器抛出 java.lang.ArrayIndexOutOfBoundsException
+
+参考[这个issue](https://github.com/apache/iotdb/issues/3417)
+
 ### 方法2：通过Docker部署
 
 Zeppelin也可以通过docker部署，但通过docker部署后，再修改配置文件、将IGinX-Zeppelin解释器加入都较为麻烦，因此还是推荐第一种做法。

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/apache/zeppelin/iginx/IginxInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/iginx/IginxInterpreter.java
@@ -633,7 +633,9 @@ public class IginxInterpreter extends AbstractInterpreter {
   }
 
   private String convertToHTMLString(String str) {
-    return "%html" + str.replace("\n", "<br>").replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;");
+    return str.contains("\n")
+        ? "%html" + str.replace("\n", "<br>").replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;")
+        : str;
   }
 
   /**

--- a/src/main/java/org/apache/zeppelin/iginx/IginxInterpreter.java
+++ b/src/main/java/org/apache/zeppelin/iginx/IginxInterpreter.java
@@ -4,8 +4,7 @@ import static cn.edu.tsinghua.iginx.utils.FileUtils.exportByteStream;
 import static org.apache.zeppelin.iginx.SimpleFileServer.getLocalHostExactAddress;
 
 import cn.edu.tsinghua.iginx.constant.GlobalConstant;
-import cn.edu.tsinghua.iginx.exceptions.ExecutionException;
-import cn.edu.tsinghua.iginx.exceptions.SessionException;
+import cn.edu.tsinghua.iginx.exception.SessionException;
 import cn.edu.tsinghua.iginx.session.QueryDataSet;
 import cn.edu.tsinghua.iginx.session.Session;
 import cn.edu.tsinghua.iginx.session.SessionExecuteSqlResult;
@@ -274,11 +273,10 @@ public class IginxInterpreter extends AbstractInterpreter {
    * @param originOutfilePath 原始的outfile路径
    * @return InterpreterResult
    * @throws SessionException
-   * @throws ExecutionException
    * @throws IOException
    */
   private InterpreterResult processOutfileSql(String sql, String originOutfilePath)
-      throws SessionException, ExecutionException, IOException {
+      throws SessionException, IOException {
 
     // 根据当前年月日时分秒毫秒生成outfile的文件夹名，将文件下载到此处
     String dateDir = new Date().toString().replace(" ", "-").replace(":", "-");
@@ -364,11 +362,9 @@ public class IginxInterpreter extends AbstractInterpreter {
    *
    * @param res QueryDataSet
    * @throws SessionException
-   * @throws ExecutionException
    * @throws IOException
    */
-  private void processExportByteStream(QueryDataSet res)
-      throws SessionException, ExecutionException, IOException {
+  private void processExportByteStream(QueryDataSet res) throws SessionException, IOException {
     String dir = res.getExportStreamDir();
 
     File dirFile = new File(dir);
@@ -427,10 +423,9 @@ public class IginxInterpreter extends AbstractInterpreter {
    * @param queryDataSet QueryDataSet
    * @return 缓存结果
    * @throws SessionException
-   * @throws ExecutionException
    */
   private List<List<byte[]>> cacheResultByteArray(QueryDataSet queryDataSet)
-      throws SessionException, ExecutionException {
+      throws SessionException {
     List<List<byte[]>> cache = new ArrayList<>();
     int rowIndex = 0;
     while (queryDataSet.hasMore() && rowIndex < Integer.parseInt(fetchSize)) {


### PR DESCRIPTION
# What's wrong:
Zeppeline shows query result as tables. When '\n' appears in one block, it will mess up the format.

# fix:
When data contains '\n', we use html wrapper instead of plain text, and replace '\n' with <br> to start a new line inside the block of a table.